### PR TITLE
use -t option in sga-align in the example

### DIFF
--- a/src/examples/sga-human-NA12878.txt
+++ b/src/examples/sga-human-NA12878.txt
@@ -187,7 +187,7 @@ ls ../input/reads.*.fastq | xargs -i ln -s {}
 #
 # Step 11: Align reads to the contigs and make bam files
 #
-for i in `ls *.fastq`; do F=`basename $i .fastq`; submit --mem 12G "sga-align --name $F final-contigs.fa $i"; done
+for i in `ls *.fastq`; do F=`basename $i .fastq`; submit --cpu 8 --mem 12G "sga-align -t 8 --name $F final-contigs.fa $i"; done
 
 # Make a directory for the refsorted and unsorted bams
 mkdir initial_sorted_bams


### PR DESCRIPTION
Seems like sga-align could be run with threads so that bwa uses a multithreaded run to be faster.  Is there any reason not to do this?

Just updated this example file since it has been my template for using the tool, if there is a better place to put together a best practices can direct it there.
