### PR TITLE
Enable independent indexing (and merging) of forward and reverse index (and fastq) files

### DIFF
--- a/src/SGA/index.cpp
+++ b/src/SGA/index.cpp
@@ -114,22 +114,29 @@ void indexInMemoryBCR()
 {
     std::cout << "Building index for " << opt::readsFile << " in memory using BCR\n";
 
-    // Parse the initial read table
-    std::vector<DNAEncodedString> readSequences;
-    SeqReader reader(opt::readsFile);
-    SeqRecord sr;
-    while(reader.get(sr))
-        readSequences.push_back(sr.seq.toString());
-    
-    BWTCA::runBauerCoxRosone(&readSequences, opt::prefix + BWT_EXT, opt::prefix + SAI_EXT);
+	if(opt::bBuildForward || opt::bBuildReverse)
+	{
+		// Parse the initial read table
+		std::vector<DNAEncodedString> readSequences;
+		SeqReader reader(opt::readsFile);
+		SeqRecord sr;
+		while(reader.get(sr))
+			readSequences.push_back(sr.seq.toString());
 
-    if(opt::bBuildReverse)
-    {
-        // Reverse all the reads
-        for(size_t i = 0; i < readSequences.size(); ++i)
-            readSequences[i] = reverse(readSequences[i].toString());
-        BWTCA::runBauerCoxRosone(&readSequences, opt::prefix + RBWT_EXT, opt::prefix + RSAI_EXT);
-    }
+		if(opt::bBuildForward)
+		{
+			BWTCA::runBauerCoxRosone(&readSequences, opt::prefix + BWT_EXT, opt::prefix + SAI_EXT);
+		}
+
+
+		if(opt::bBuildReverse)
+		{
+			// Reverse all the reads
+			for(size_t i = 0; i < readSequences.size(); ++i)
+				readSequences[i] = reverse(readSequences[i].toString());
+			BWTCA::runBauerCoxRosone(&readSequences, opt::prefix + RBWT_EXT, opt::prefix + RSAI_EXT);
+		}
+	}
 }
 
 //
@@ -137,22 +144,27 @@ void indexInMemorySAIS()
 {
     std::cout << "Building index for " << opt::readsFile << " in memory\n";
 
-    // Parse the initial read table
-    ReadTable* pRT = new ReadTable(opt::readsFile);
+	if(opt::bBuildForward || opt::bBuildReverse){
+		// Parse the initial read table
+		ReadTable* pRT = new ReadTable(opt::readsFile);
 
-    // Create and write the suffix array for the forward reads
-    buildIndexForTable(opt::prefix, pRT, false);
-    
-    if(opt::bBuildReverse)
-    {
-        // Reverse all the reads
-        pRT->reverseAll();
+		// Create and write the suffix array for the forward reads
+		if(opt::bBuildForward)
+		{
+			buildIndexForTable(opt::prefix, pRT, false);
+		}
 
-        // Build the reverse suffix array
-        buildIndexForTable(opt::prefix, pRT, true);
-    }
+		if(opt::bBuildReverse)
+		{
+			// Reverse all the reads
+			pRT->reverseAll();
 
-    delete pRT;
+			// Build the reverse suffix array
+			buildIndexForTable(opt::prefix, pRT, true);
+		}
+
+		delete pRT;
+	}
 }
 
 //
@@ -170,12 +182,12 @@ void indexOnDisk()
     parameters.bBuildReverse = false;
     parameters.bUseBCR = (opt::algorithm == "bcr");
 		
-		if(opt::bBuildForward)
-		{
-			buildBWTDisk(parameters);
-		}
+	if(opt::bBuildForward)
+	{
+		buildBWTDisk(parameters);
+	}
 		
-    if(opt::bBuildReverse)
+	if(opt::bBuildReverse)
     {
         parameters.bwtExtension = RBWT_EXT;
         parameters.saiExtension = RSAI_EXT;

--- a/src/SGA/merge.cpp
+++ b/src/SGA/merge.cpp
@@ -57,9 +57,9 @@ namespace opt
     static int numThreads = 1;
     static bool bRemove;
     static int gapArrayStorage = 4;
-		static bool bMergeSequence = true;
-		static bool bMergeForward = true;
-		static bool bMergeReverse = true;
+	static bool bMergeSequence = true;
+	static bool bMergeForward = true;
+	static bool bMergeReverse = true;
 }
 
 static const char* shortopts = "p:m:t:g:vr";
@@ -101,10 +101,10 @@ int mergeMain(int argc, char** argv)
     }
 
     // Merge the indices
-		if(opt::bMergeForward)
-		{
-			mergeIndependentIndices(inFiles[0], inFiles[1], opt::prefix, BWT_EXT, SAI_EXT, false, opt::numThreads, opt::gapArrayStorage);
-		}
+	if(opt::bMergeForward)
+	{
+		mergeIndependentIndices(inFiles[0], inFiles[1], opt::prefix, BWT_EXT, SAI_EXT, false, opt::numThreads, opt::gapArrayStorage);
+	}
 
     // Skip merging the reverse indices if the reverse bwt file does not exist. 
     std::string rbwt_filename_1 = prefix1 + RBWT_EXT;
@@ -116,15 +116,15 @@ int mergeMain(int argc, char** argv)
     int ret2 = stat(rbwt_filename_2.c_str(), &file_s_2);
 
     if((ret1 == 0 || ret2 == 0) && opt::bMergeReverse)
-		{
-			mergeIndependentIndices(inFiles[0], inFiles[1], opt::prefix, RBWT_EXT, RSAI_EXT, true, opt::numThreads, opt::gapArrayStorage);
-		}
+	{
+		mergeIndependentIndices(inFiles[0], inFiles[1], opt::prefix, RBWT_EXT, RSAI_EXT, true, opt::numThreads, opt::gapArrayStorage);
+	}
 		
     // Merge the read files
-		if(opt::bMergeSequence)
-		{
-			mergeReadFiles(inFiles[0], inFiles[1], opt::prefix);
-		}
+	if(opt::bMergeSequence)
+	{
+		mergeReadFiles(inFiles[0], inFiles[1], opt::prefix);
+	}
 
     if(opt::bRemove)
     {
@@ -169,9 +169,9 @@ void parseMergeOptions(int argc, char** argv)
             case 't': arg >> opt::numThreads; break;
             case 'g': arg >> opt::gapArrayStorage; break;
             case 'v': opt::verbose++; break;
-						case OPT_NO_SEQUENCE: opt::bMergeSequence = false; break;
-						case OPT_NO_FWD: opt::bMergeForward = false; break;
-						case OPT_NO_REV: opt::bMergeReverse = false; break;
+			case OPT_NO_SEQUENCE: opt::bMergeSequence = false; break;
+			case OPT_NO_FWD: opt::bMergeForward = false; break;
+			case OPT_NO_REV: opt::bMergeReverse = false; break;
             case OPT_HELP:
                 std::cout << MERGE_USAGE_MESSAGE;
                 exit(EXIT_SUCCESS);


### PR DESCRIPTION
Hi Jared,

these changes enables to separate the
- index creation of the forward and the reverse index 
- merging of the forward / reverse index and fastq file

which allows the independent  forward / reverse index creation and forward / reverse index / fastq merging on separate machines.

Hope this helps,
Matthias
