### PR TITLE
ld_set is static inline. Closes #29

### DIFF
--- a/src/Thirdparty/bcr.c
+++ b/src/Thirdparty/bcr.c
@@ -144,7 +144,7 @@ void ld_destroy(longdna_t *ld)
 	free(ld->a); free(ld);
 }
 
-inline void ld_set(longdna_t *h, int64_t x, int c)
+static inline void ld_set(longdna_t *h, int64_t x, int c)
 {
 	int k = x >> LD_SHIFT, l = x & LD_MASK;
 	if (k >= h->max) {


### PR DESCRIPTION
Fix a compiler error.

```
Undefined symbols for architecture x86_64:
  "_ld_set", referenced from:
      _bcr_append in libthirdparty.a(bcr.o)
```
