### PR TITLE
bubble orientation fix

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,3 +9,6 @@ depcomp
 install-sh
 missing
 build*
+*.o
+*.a
+Makefile


### PR DESCRIPTION
Fixed issue where a bubble would be labeled as cleanly removable
even if the variant walks from X to Y had different orientations
for Y.
