### PR TITLE
removed sga stats requirement for reverse index

### DIFF
--- a/src/Algorithm/StatsProcess.cpp
+++ b/src/Algorithm/StatsProcess.cpp
@@ -19,15 +19,24 @@ StatsProcess::StatsProcess(const BWT* pBWT, const BWT* pRBWT, int kmerLength, in
                             m_kmerLength(kmerLength),
                             m_minOverlap(minOverlap),
                             m_branchCutoff(branchCutoff),
-                            m_bNoOverlap(bNoOverlap)
+                            m_bNoOverlap(bNoOverlap),
+                            m_pAllOverlapper(NULL)
 {
-    m_pAllOverlapper = new OverlapAlgorithm(m_pBWT, m_pRBWT, 0.05, 16, 16, false, m_branchCutoff);
+    if (!m_bNoOverlap)
+    {
+        assert(m_pRBWT);
+        m_pAllOverlapper = new OverlapAlgorithm(m_pBWT, m_pRBWT, 0.05, 16, 16, false, m_branchCutoff);
+    }
 }
 
 //
 StatsProcess::~StatsProcess()
 {
-    delete m_pAllOverlapper;
+    if(m_pAllOverlapper)
+    {
+        delete m_pAllOverlapper;
+        m_pAllOverlapper = NULL;
+    }
 }
 
 //

--- a/src/SGA/stats.cpp
+++ b/src/SGA/stats.cpp
@@ -104,7 +104,11 @@ int statsMain(int argc, char** argv)
     Timer* pTimer = new Timer(PROGRAM_IDENT);
 
     BWT* pBWT = new BWT(opt::prefix + BWT_EXT, opt::sampleRate);
-    BWT* pRBWT = new BWT(opt::prefix + RBWT_EXT, opt::sampleRate);
+    BWT* pRBWT = NULL;
+
+    // Do not need the reverse BWT if the overlap statistics are disabled
+    if (!opt::bNoOverlap)
+        pRBWT = new BWT(opt::prefix + RBWT_EXT, opt::sampleRate);
 
     if(opt::bPrintRunLengths)
     {
@@ -147,7 +151,8 @@ int statsMain(int argc, char** argv)
     }
 
     delete pBWT;
-    delete pRBWT;
+    if (pRBWT)
+        delete pRBWT;
     delete pTimer;
 
     if(opt::numThreads > 1)


### PR DESCRIPTION
sga stats does not require the reverse index if using the --no-overlap option.
