### PR TITLE
A small change that make the project compilable with c++11

### DIFF
--- a/src/SuffixTools/SparseGapArray.h
+++ b/src/SuffixTools/SparseGapArray.h
@@ -320,7 +320,7 @@ class SparseGapArray : public GapArray
         //
         void initOverflow(size_t i, OverflowStorage c)
         {
-            m_overflow.insert(std::make_pair<size_t, OverflowStorage>(i, c));
+            m_overflow.insert(std::make_pair(i, c));
         }
 
         //


### PR DESCRIPTION
This change was necessary for my configuration to compile the project using c++11 instead of c++98 using the command:
./configure CXX='g++ -std=c++11'
A speed improvement with c++11 may be expected thanks to the the new move constructor semantic introduced by the language. This should indeed save some memory allocation time for example when a string object is returned by the function. I didn't compare the execution time with a binary produced with c++98.
