### PR TITLE
Use gzip for discarded reads if outfile has ".gz" as extension

### DIFF
--- a/src/SGA/filter.cpp
+++ b/src/SGA/filter.cpp
@@ -293,7 +293,7 @@ void parseFilterOptions(int argc, char** argv)
     else
     {
         if(isGzip(opt::outFile))
-            opt::discardFile = stripFilename(opt::outFile) + ".discard.fa.gz";
+            opt::discardFile = stripFilename(opt::outFile) + ".discard.fa" + GZIP_EXT;
         else
             opt::discardFile = stripFilename(opt::outFile) + ".discard.fa";
     }


### PR DESCRIPTION
This commit tests if outfile is gzipped (when provided at command-line) and in this case compress the file of the discarded reads.
