### PR TITLE
Kmer Count along a sequence (kmer-plot)

### DIFF
--- a/src/SGA/kmer-count.cpp
+++ b/src/SGA/kmer-count.cpp
@@ -4,7 +4,7 @@
 // Released under the GPL
 //-----------------------------------------------
 //
-// Kmer-count - Correct sequencing errors in reads using the FM-index
+// Kmer-count - Counting kmers in BWT or Sequence Files
 //
 
 #include <kmer-count.h>


### PR DESCRIPTION
For a particular input sequence, output the kmer counts from one or more bwt's.

Useful if you want to see the kmer coverage over a specific sequence.

In spirit of Amos kmer-cov-plot
