### PR TITLE
BUG: fix legend call signature for matplotlib 1.5

### DIFF
--- a/src/bin/sga-preqc-report.py
+++ b/src/bin/sga-preqc-report.py
@@ -330,7 +330,7 @@ def plot_legend(ax, data):
                 linestyle='-', marker=d['plot_marker'],
                 color=d['plot_color']))
         names.append(d['name'])
-    ax.legend(proxy_arts, names, 2, bbox_to_anchor=(0,1), borderaxespad=0.)
+    ax.legend(proxy_arts, names, loc=2, bbox_to_anchor=(0,1), borderaxespad=0.)
     ax.set_frame_on(False)
     ax.tick_params(axis='x', which='both', bottom='off', top='off', labelbottom='off')
     ax.tick_params(axis='y', which='both', left='off', right='off', labelleft='off')


### PR DESCRIPTION
Please note that I have not tested this myself, but the change should be compatible with matplotlib 1.5 as well as older matplotlib versions. If someone closer to the project could test and confirm this before merge, I would appreciate it!