### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@
 #        --tumor-bam=/data/tumor.bam --normal-bam=/data/normal.bam \
 #        --reference=/data/reference.fa /data/input.vcf
 #
+# You can also invoke other sga scripts, such as sga-preqc-report:
+#   docker run -v /path/of/sga/repo:/data/ \
+#       --entrypoint /src/sga-0.10.14/src/bin/sga-preqc-report.py \
+#       sga-docker /data/src/examples/preqc/{bird,fish,human,oyster,snake,yeast}.preqc
 #
 FROM ubuntu:14.04
 MAINTAINER Jonathan Dursi <Jonathan.Dursi@oicr.on.ca> 
@@ -24,6 +28,7 @@ VOLUME /data
 WORKDIR /data
 
 # get ubuntu packages
+# incl python matplotlib for preqc
 RUN apt-get update && \
     apt-get install -y \
         automake \
@@ -35,6 +40,7 @@ RUN apt-get update && \
         libjemalloc-dev \
         libsparsehash-dev \
         libz-dev \
+        python-matplotlib \
         wget \
         zlib1g-dev 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update && \
         autotools-dev \
         build-essential \
         cmake \
-        git \
         libhts-dev \
         libhts0 \
         libjemalloc-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# SGA docker
+# Version 0.1
+# Runs SGA ( http://github.com/jts/sga ) 
+#
+# Creates SGA-in-a-docker, such that you can run the dockerized SGA
+# much as you would run the local SGA executable.
+# 
+# To build:
+#    docker build -t sga-docker [path containing DOCKERFILE]
+# if the Dockerfile is local, otherwise:
+#    docker build github.com/jts/sga
+#    
+# Once built, you can invoke sga-docker as you would sga, eg:
+#    docker run -v /path/to/local/data/data/:/data/ \
+#       sga-docker somatic-variant-filters --annotate-only --threads=N \
+#        --tumor-bam=/data/tumor.bam --normal-bam=/data/normal.bam \
+#        --reference=/data/reference.fa input.vcf
+#
+#
+FROM ubuntu:14.04
+MAINTAINER Jonathan Dursi <Jonathan.Dursi@oicr.on.ca> 
+LABEL Description="Runs SGA variant annotation on candidate indels against tumour and normal bams" Vendor="OICR" Version="0.1"
+
+# get ubuntu packages
+RUN apt-get update && \
+    apt-get install -y \
+        automake \
+        autotools-dev \
+        build-essential \
+        cmake \
+        git \
+        libhts-dev \
+        libhts0 \
+        libjemalloc-dev \
+        libsparsehash-dev \
+        libz-dev \
+        wget \
+        zlib1g-dev 
+
+# build remaining dependencies:
+# bamtools
+RUN mkdir -p /deps && \
+    cd /deps && \
+    wget https://github.com/pezmaster31/bamtools/archive/v2.4.0.tar.gz && \
+    tar -xzvf v2.4.0.tar.gz && \
+    rm v2.4.0.tar.gz && \
+    cd bamtools-2.4.0 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make
+
+# build SGA
+RUN mkdir -p /src && \
+    cd /src && \
+    wget https://github.com/jts/sga/archive/v0.10.14.tar.gz && \
+    tar -xzvf v0.10.14.tar.gz && \
+    rm v0.10.14.tar.gz && \
+    cd sga-0.10.14/src && \
+    ./autogen.sh && \
+    ./configure --with-bamtools=/deps/bamtools-2.4.0 --with-jemalloc=/usr --prefix=/usr/local && \
+    make && \
+    make install
+
+
+ENTRYPOINT ["/usr/local/bin/sga"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,20 @@
 # To build:
 #    docker build -t sga-docker [path containing DOCKERFILE]
 # if the Dockerfile is local, otherwise:
-#    docker build github.com/jts/sga
+#    docker build -t sga-docker github.com/jts/sga
 #    
 # Once built, you can invoke sga-docker as you would sga, eg:
 #    docker run -v /path/to/local/data/data/:/data/ \
-#       sga-docker somatic-variant-filters --annotate-only --threads=N \
+#       sga-docker somatic-variant-filters --annotate-only --threads=2 \
 #        --tumor-bam=/data/tumor.bam --normal-bam=/data/normal.bam \
-#        --reference=/data/reference.fa input.vcf
+#        --reference=/data/reference.fa /data/input.vcf
 #
 #
 FROM ubuntu:14.04
 MAINTAINER Jonathan Dursi <Jonathan.Dursi@oicr.on.ca> 
 LABEL Description="Runs SGA variant annotation on candidate indels against tumour and normal bams" Vendor="OICR" Version="0.1"
+VOLUME /data
+WORKDIR /data
 
 # get ubuntu packages
 RUN apt-get update && \


### PR DESCRIPTION
I'm having to make a docker image for an SGA somatic-variant-filter pipeline, so as part of that have made an SGA docker file; feel free to incorporate this into the sga repository if useful.

Note that in this docker image I have _not_ included pysam or ruffus - or even python; this is just for running the SGA executable.  We could also put together a dockerized version of the entire SGA workflow, but that would likely have a different interface; maybe something like that could go in sga-extra?