### PR TITLE
Fix gcc6 issues - made code C++14 friendly

### DIFF
--- a/src/SGA/rmdup.cpp
+++ b/src/SGA/rmdup.cpp
@@ -232,7 +232,7 @@ std::string parseDupHits(const StringVector& hitsFilenames, const std::string& o
     while(!done)
     {
         // Parse a line from the current file
-        bool valid = getline(*reader_vec[currReaderIdx], line);
+        bool valid = static_cast<bool>(getline(*reader_vec[currReaderIdx], line));
         ++numRead;
         // Deal with switching the active reader and the end of files
         if(!valid || numRead == buffer_size)

--- a/src/SuffixTools/STCommon.h
+++ b/src/SuffixTools/STCommon.h
@@ -96,7 +96,7 @@ struct SAElem
         // Masks
         static const uint8_t ID_BITS = 36; // Allows up to 68 billion IDs
         static const uint8_t POS_BITS = 64 - ID_BITS;
-        static const uint64_t HIGH_MASK = ~0 << POS_BITS;
+        static const uint64_t HIGH_MASK = ~0llu << POS_BITS;
         static const uint64_t LOW_MASK = ~HIGH_MASK;
 };
 

--- a/src/Util/ClusterReader.cpp
+++ b/src/Util/ClusterReader.cpp
@@ -67,7 +67,7 @@ bool ClusterReader::generate(ClusterVector& out)
 bool ClusterReader::readCluster(ClusterRecord& record)
 {
     std::string line;
-    bool good = getline(*m_pReader, line);
+    bool good = static_cast<bool>(getline(*m_pReader, line));
     if(!good || line.empty())
         return false;
     std::stringstream parser(line);

--- a/src/Util/StdAlnTools.cpp
+++ b/src/Util/StdAlnTools.cpp
@@ -119,7 +119,7 @@ std::string StdAlnTools::expandCigar(const std::string& cigar)
     char code;
     while(parser >> length)
     {
-        bool success = parser >> code;
+        bool success = static_cast<bool>(parser >> code);
         expanded.append(length, code);
         assert(success);
         (void)success;


### PR DESCRIPTION
As per https://gcc.gnu.org/gcc-6/changes.html , the default C++ dialect in GCC 6 is updated from GNU++98 all the way to GNU++14. This causes compile errors for C++ programs that are not C++14 (or C++11) compliant, and do not request a specific dialect.

With this pull request, SGA can be compiled by GCC 6.0.0 using dialects C++98, C++11, and C++14. I also checked older GCC versions (4.8.4 on Trusty and 5.2.1 on Wily) for C++98 and C++11, but not C++14.

Note- SGA depends on BamTools, which has its own share of GCC 6 problems, which I addressed here: https://github.com/pezmaster31/bamtools/pull/116 . If I understand correctly, the proposed fix forces `libbamtools.a` to be built using the C++98 ABI. With the default configuration, SGA would then be built using the C++14 ABI. Sample differences are here: https://gcc.gnu.org/wiki/Cxx11AbiCompatibility (couldn't find one about C++14 ABI). A quick glance suggests there are no problematic symbols being used.
