### PR TITLE
sga-bam2de.pl: Fix samtools sort for samtools 1.3

### DIFF
--- a/src/bin/sga-bam2de.pl
+++ b/src/bin/sga-bam2de.pl
@@ -62,7 +62,7 @@ runCmd($cmd);
 runCmd("awk \'\$2 >= $hist_min\' $prefix.tmp.hist > $prefix.hist");
 
 # sort 
-$cmd = "samtools sort $prefix.diffcontigs.bam $prefix.diffcontigs.sorted";
+$cmd = "samtools sort -\@$numThreads $prefix.diffcontigs.bam -o $prefix.diffcontigs.sorted.bam";
 runCmd($cmd);
 
 # distance est


### PR DESCRIPTION
Fix the error:
```
[bam_sort] Use -T PREFIX / -o FILE to specify temporary and final output files
```

Fixes jts/sga#118.