### PR TITLE
set language standard

### DIFF
--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,63 @@
+#
+# Dockerfile meant for build testing only.
+#
+# Synopsis:
+# - install prerequisites from debian:stable
+# - install gcc-6 from debian:testing
+# - clone bamtools (NOTE: fix for gcc-6 not included in currently latest tag 2.4.0)
+# - build bamtools
+# - install bamtools in /usr/local
+# - copy (sga/) src from Dockerfile context
+# - build sga
+# - install sga in /usr/local
+#
+FROM debian:stable
+MAINTAINER Matei David <matei.david.at.oicr.on.ca>
+ARG DEBIAN_FRONTEND=noninteractive
+LABEL Description="Dockerfile meant for build testing only."
+WORKDIR /tmp
+
+# enable debian:testing
+RUN echo 'APT::Default-Release "stable";' >/etc/apt/apt.conf.d/99defaultrelease && \
+    mv /etc/apt/sources.list /etc/apt/sources.list.d/stable.list && \
+    sed 's/stable/testing/g' </etc/apt/sources.list.d/stable.list >/etc/apt/sources.list.d/testing.list
+
+# install prerequisites from stable
+RUN apt-get update -y && \
+    apt-get install -y \
+        automake \
+        autotools-dev \
+        build-essential \
+        cmake \
+        git \
+        libjemalloc-dev \
+        libsparsehash-dev \
+        libz-dev \
+        wget
+
+# install gcc-6 from testing
+RUN apt-get install -y -t testing \
+    g++-6
+ENV CC=gcc-6
+ENV CXX=g++-6
+
+# build bamtools
+RUN git clone --depth 1 https://github.com/pezmaster31/bamtools.git && \
+    cd bamtools && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install
+
+ADD src /tmp/sga/src/
+RUN cd /tmp/sga/src && \
+    ./autogen.sh && \
+    ./configure --with-bamtools=/usr/local --with-jemalloc=/usr && \
+    make && \
+    make install
+
+VOLUME /data
+WORKDIR /data
+ENTRYPOINT ["/usr/local/bin/sga"]
+CMD ["--help"]

--- a/src/SGA/rmdup.cpp
+++ b/src/SGA/rmdup.cpp
@@ -232,7 +232,7 @@ std::string parseDupHits(const StringVector& hitsFilenames, const std::string& o
     while(!done)
     {
         // Parse a line from the current file
-        bool valid = static_cast<bool>(getline(*reader_vec[currReaderIdx], line));
+        bool valid = getline(*reader_vec[currReaderIdx], line);
         ++numRead;
         // Deal with switching the active reader and the end of files
         if(!valid || numRead == buffer_size)

--- a/src/Util/ClusterReader.cpp
+++ b/src/Util/ClusterReader.cpp
@@ -67,7 +67,7 @@ bool ClusterReader::generate(ClusterVector& out)
 bool ClusterReader::readCluster(ClusterRecord& record)
 {
     std::string line;
-    bool good = static_cast<bool>(getline(*m_pReader, line));
+    bool good = getline(*m_pReader, line);
     if(!good || line.empty())
         return false;
     std::stringstream parser(line);

--- a/src/Util/StdAlnTools.cpp
+++ b/src/Util/StdAlnTools.cpp
@@ -119,7 +119,7 @@ std::string StdAlnTools::expandCigar(const std::string& cigar)
     char code;
     while(parser >> length)
     {
-        bool success = static_cast<bool>(parser >> code);
+        bool success = parser >> code;
         expanded.append(length, code);
         assert(success);
         (void)success;

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -92,8 +92,8 @@ fi
 
 # Set compiler flags.
 AC_SUBST(AM_CXXFLAGS, "-Wall -Wextra $fail_on_warning -Wno-unknown-pragmas")
-AC_SUBST(CXXFLAGS, "-O3")
-AC_SUBST(CFLAGS, "-O3")
+AC_SUBST(CXXFLAGS, "-std=c++98 -O3")
+AC_SUBST(CFLAGS, "-std=gnu99 -O3")
 AC_SUBST(CPPFLAGS, "$CPPFLAGS $openmp_cppflags $sparsehash_include $bamtools_include")
 AC_SUBST(LDFLAGS, "$openmp_cppflags $external_malloc_ldflags $bamtools_ldflags $LDFLAGS")
 


### PR DESCRIPTION
I reverted the `getline` modifications (which were not comprehensive), and instead set the entire language standard to `c++98/gnu99`. I added a build testing Dockerfile, which currently works with `gcc-6.1.1`. Note, the `gcc6` fix for BamTools is not yet present in the latest tagged release (2.4.0), so BamTools must be installed with `git clone` instead of `wget`.