### PR TITLE
sga-bam2de.pl: Use DistanceEst -l30

### DIFF
--- a/src/bin/sga-bam2de.pl
+++ b/src/bin/sga-bam2de.pl
@@ -9,7 +9,7 @@ my $minLength = 200;
 my $prefix = "";
 my $numThreads = 1;
 my $mind = -99; # minimum gap size to pass to abyss
-my $mina = 100; # minimum alignment length to pass to abyss
+my $mina = 30; # minimum alignment length to pass to abyss
 
 # Filter the abyss distance est histogram to remove insert sizes
 # with fewer than hist_min data points


### PR DESCRIPTION
Use DistanceEst -l30 rather than -l100. The default minimum alignment score of BWA-MEM is 30, and so also 30 bp in length for a perfect match.

Fix the following error, which occurs when there's a contig that is smaller than the minimum alignment length.
```
DistanceEst: MLE.cpp:180: int maximumLikelihoodEstimate(unsigned int, int, int, const std::vector<int>&, const PMF&, unsigned int, unsigned int, bool, unsigned int&): Assertion `len1 >= l' failed.
Aborted
```

Fixes #142.