### PR TITLE
Fix error: call to 'abs' is ambiguous

### DIFF
--- a/src/Algorithm/GapFillProcess.cpp
+++ b/src/Algorithm/GapFillProcess.cpp
@@ -233,7 +233,7 @@ GapFillReturnCode GapFillProcess::selectGapSequence(int estimatedSize, const Str
 
     for(size_t i = 0; i < sequences.size(); ++i)
     {
-        int diff = abs(sequences[i].size() - estimatedSize);
+        int diff = abs((int)sequences[i].size() - estimatedSize);
         //printf("ES: %d S: %zu D: %d\n", estimatedSize, sequences[i].size(), diff);
 
         if(diff < selectedSizeDiff)

--- a/src/Util/VariantIndex.cpp
+++ b/src/Util/VariantIndex.cpp
@@ -86,7 +86,7 @@ VariantRecordVector VariantIndex::getNearVariants(const std::string& reference,
         for(size_t vi = 0; vi < bucket.size(); ++vi)
         {
             const VariantRecord& record = m_records[bucket[vi]];
-            if(abs(record.position - position) < distance)
+            if(abs((int)record.position - position) < distance)
                 out.push_back(record);
         }
     }


### PR DESCRIPTION
An unsigned int minus a signed int yields an unsigned int.
Calling abs on an unsigned int is ambiguous.
Cast the unsigned int to a signed int before calling abs.

Fixes https://github.com/jts/sga/issues/141