### PR TITLE
bug fixed for samtools sort

### DIFF
--- a/src/bin/sga-bam2de.pl
+++ b/src/bin/sga-bam2de.pl
@@ -62,7 +62,7 @@ runCmd($cmd);
 runCmd("awk \'\$2 >= $hist_min\' $prefix.tmp.hist > $prefix.hist");
 
 # sort 
-$cmd = "samtools sort -\@$numThreads -o $prefix.diffcontigs.sorted.bam $prefix.diffcontigs.bam";
+$cmd = "samtools sort -\@ $numThreads $prefix.diffcontigs.bam $prefix.diffcontigs.sorted";
 runCmd($cmd);
 
 # distance est


### PR DESCRIPTION
In my environment, I use apt to install samtools and get the help description of samtools sort as follows:

test@sga1:/home/test/sga$ samtools sort
Usage:   samtools sort [options] <in.bam> <out.prefix>
Options: -n        sort by read name
         -f        use <out.prefix> as full file name instead of prefix
         -o        final output to stdout
         -l INT    compression level, from 0 to 9 [-1]
         -@ INT    number of sorting and compression threads [1]
         -m INT    max memory per thread; suffix K/M/G recognized [768M]

the parameter -o of samtools sort is for stdout rather than for user-defined output filename. It will cause failure when calling sga-bam2de.pl. Since many version of samtool are available in the world, it will be better to simplify the general usage of samtools. 
