### PR TITLE
Like PR #123, use samtools >=1 `sort` format in sga-align script

### DIFF
--- a/src/bin/sga-align
+++ b/src/bin/sga-align
@@ -51,7 +51,7 @@ def runMerge(inFiles, outFile):
 def runSort(inFile, outFile):
 
     (outPrefix, fileExtension) = os.path.splitext(outFile)
-    cmd = "samtools sort %s %s" % (inFile, outPrefix)
+    cmd = "samtools sort %s -o %s.bam" % (inFile, outPrefix)
     runCmd(cmd)
     
     #cmd = "samtools index %s" % (outFile)


### PR DESCRIPTION
Small fix for `samtools sort` in sga-align, which allows for using newer samtools (anything 1.0 or greater). 

This way both `sga-align` and `sga-bam2de.pl` are in line with the samtools api, and you don't need to switch between samtools versions to use them (or use `sga` <= 0.10.14).