### PR TITLE
 multithread for samtools sort in sga-align, and fix devision by zero when bootstrap fails in sga-astat

### DIFF
--- a/src/bin/sga-align
+++ b/src/bin/sga-align
@@ -49,9 +49,9 @@ def runMerge(inFiles, outFile):
     runCmd(cmd)
 
 def runSort(inFile, outFile):
-
+    global threads
     (outPrefix, fileExtension) = os.path.splitext(outFile)
-    cmd = "samtools sort %s -o %s.bam" % (inFile, outPrefix)
+    cmd = "samtools sort -@ %d %s -o %s.bam" % (threads, inFile, outPrefix)
     runCmd(cmd)
     
     #cmd = "samtools index %s" % (outFile)

--- a/src/bin/sga-astat.py
+++ b/src/bin/sga-astat.py
@@ -150,6 +150,8 @@ if genomeSize == 0:
                 bootstrapReads += cd.n
 
         # Estimate arrival rate based on unique contigs
+        if bootstrapLen == 0 or bootstrapReads == 0:
+            continue  # failed 
         arrivalRate = float(bootstrapReads) / float(bootstrapLen)
         genomeSize = int(totalReads / arrivalRate)
         sys.stderr.write('Iteration ' + str(i) + ' arrival rate: ' + str(arrivalRate) + '\n');
@@ -181,4 +183,3 @@ for cd in contigData:
 
 sys.stderr.write('Sum unique bases in contigs >= %d bp in length: %d\n' % (minLength, sumUnique))
 sys.stderr.write('Sum repeat bases in contigs >= %d bp in length: %d\n' % (minLength, sumRepeat))
-


### PR DESCRIPTION
###  multithread for samtools sort in sga-align
It is a speed bottleneck. `samtools sort` has a multithread feature but is not used.

### devision by zero when bootstrap fails in sga-astat.py
I just simply skip the loop when `bootstrapLen == 0 or bootstrapReads == 0`.