### PR TITLE
fix: bool convert problem 

### DIFF
--- a/src/SGA/rmdup.cpp
+++ b/src/SGA/rmdup.cpp
@@ -232,7 +232,7 @@ std::string parseDupHits(const StringVector& hitsFilenames, const std::string& o
     while(!done)
     {
         // Parse a line from the current file
-        bool valid = getline(*reader_vec[currReaderIdx], line);
+        bool valid = static_cast<bool>(getline(*reader_vec[currReaderIdx], line));
         ++numRead;
         // Deal with switching the active reader and the end of files
         if(!valid || numRead == buffer_size)

--- a/src/Util/ClusterReader.cpp
+++ b/src/Util/ClusterReader.cpp
@@ -67,7 +67,7 @@ bool ClusterReader::generate(ClusterVector& out)
 bool ClusterReader::readCluster(ClusterRecord& record)
 {
     std::string line;
-    bool good = getline(*m_pReader, line);
+    bool good = static_cast<bool>(getline(*m_pReader, line));
     if(!good || line.empty())
         return false;
     std::stringstream parser(line);

--- a/src/Util/StdAlnTools.cpp
+++ b/src/Util/StdAlnTools.cpp
@@ -119,7 +119,7 @@ std::string StdAlnTools::expandCigar(const std::string& cigar)
     char code;
     while(parser >> length)
     {
-        bool success = parser >> code;
+        bool success = static_cast<bool>(parser >> code);
         expanded.append(length, code);
         assert(success);
         (void)success;


### PR DESCRIPTION
for example

```
ClusterReader.cpp:70:24: error: cannot convert ‘std::basic_istream<char>’ to ‘bool’ in initialization
   70 |     bool good = getline(*m_pReader, line);
```